### PR TITLE
FileSource fix: proper working with relative file path when app was started by a task scheduler.

### DIFF
--- a/Vostok.Configuration.Sources/File/FileSourceSettings.cs
+++ b/Vostok.Configuration.Sources/File/FileSourceSettings.cs
@@ -31,6 +31,17 @@ namespace Vostok.Configuration.Sources.File
         /// </summary>
         public TimeSpan FileWatcherPeriod { get; set; } = TimeSpan.FromSeconds(5);
 
+        [Pure]
+        [NotNull]
+        internal FileSourceSettings WithFilePath(string filePath)
+        {
+            return new FileSourceSettings(filePath)
+            {
+                Encoding = Encoding,
+                FileWatcherPeriod = FileWatcherPeriod
+            };
+        }
+
         #region Equality
 
         public override bool Equals(object obj)


### PR DESCRIPTION
Why AppDomain.CurrentDomain.BaseDirectory ?
Because of tricky behavior of other methods:
Method \ execution type | windows console run | windows TaskScheduler run | windows iis-express run | ubuntu dotnet run
------------------------- | -------------------------- | --------------------------  | -------------------------- | --------------------------
Environment.CurrentDirectory() | folder with app binaries | `C:\Windows\system32\` | `C:\Program Files (x86)\IIS Express\` | folder where **dotnet run was called**
Directory.GetCurrentDirectory() | folder with app binaries | `C:\Windows\system32\` | `C:\Program Files (x86)\IIS Express\` | folder where **dotnet run was called**
Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) | folder with app binaries | folder with app binaries | `C:\Users\{current_user}\AppData\Local\Temp\Temporary ASP.NET Files\.....` | folder with app binaries
AppDomain.CurrentDomain.BaseDirectory | folder with app binaries | folder with app binaries | folder with app binaries |  folder with app binaries